### PR TITLE
Move from abandoned mnapoli/php-di to php-di/php-di and support ~4.4 and ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "mnapoli/silly": "~1.1",
-        "mnapoli/php-di": "~4.4"
+        "php-di/php-di": "~4.4 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"


### PR DESCRIPTION
Came across the abandomened of mnapoli/php-di when setting up a  new silly project. Current PHP-DI docs (for 5) also mis match with the package's expected 4.4 target release. This PR allows both 4.4 and 5 to be used.
