### PR TITLE
Updating php-di version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "mnapoli/silly": "~1.1",
-        "php-di/php-di": "~4.4 || ^5.0"
+        "php-di/php-di": "^6.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "mnapoli/silly": "~1.1",
-        "php-di/php-di": "^6.0.0"
+        "php-di/php-di": "~4.4 || ^5.0 || ^6.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"


### PR DESCRIPTION
Hi,
I am using Slim Bridge with PhpDi and silly-php-di in the same project and the versions of php-di were conflicting, so I tried to upgrade them to the newer version, and everything seems working fine.

Is there any reason for not upgrade it to a newer version?


### EDIT
just find out why
![image](https://user-images.githubusercontent.com/248805/38319950-1d6f93ba-382b-11e8-83be-2ebfac425a6f.png)
Php-Di 6 dropped support for php<=5.6, are you still planning to support it?
php5.6 end of file is set to be at the end of this year, and 5.5 is already dead ([more info](http://php.net/supported-versions.php))

### EDIT-2
just added 6.0 as
```
"php-di/php-di": "~4.4 || ^5.0 || ^6.0.0"
```
so now the build is passing.