### PR TITLE
Upgrade DI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     },
     "require": {
-        "mnapoli/silly": "~1.1",
-        "php-di/php-di": "~4.4 || ^5.0 || ^6.0.0"
+        "mnapoli/silly": "^1.8",
+        "php-di/php-di": "~4.4 || ^5.0 || ^6.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.5"
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "mnapoli/silly": "^1.8",
-        "php-di/php-di": "~4.4 || ^5.0 || ^6.4"
+        "php-di/php-di": "~4.4 || ^5.0 || ^6.4 || 7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "php-di/php-di": "~4.4 || ^5.0 || ^6.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "~9.5"
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -3,7 +3,6 @@
 namespace Silly\Edition\PhpDi;
 
 use DI\Container;
-use DI\ContainerBuilder;
 
 /**
  * Silly CLI application using PHP-DI.
@@ -28,6 +27,6 @@ class Application extends \Silly\Application
      */
     protected function createContainer()
     {
-        return ContainerBuilder::buildDevContainer();
+        return new Container();
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -27,7 +27,7 @@ class ApplicationTest extends TestCase
      */
     public function it_should_accept_the_container_in_the_constructor()
     {
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container();
 
         $app = new Application('name', 'version', $container);
 
@@ -39,7 +39,7 @@ class ApplicationTest extends TestCase
      */
     public function it_should_inject_in_callables_parameters()
     {
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container();
 
         $app = new Application('name', 'version', $container);
         $app->setAutoExit(false);

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -8,8 +8,9 @@ use Silly\Edition\PhpDi\Application;
 use Silly\Edition\PhpDi\Test\Mock\SpyOutput;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface as Out;
+use PHPUnit\Framework\TestCase;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
Include support for PHP-DI 7.0, and which is backwards compatible with PHP-DI 6.0. Earlier versions do not seem to work.